### PR TITLE
Add associate form navigation

### DIFF
--- a/client/app/associate-form.js
+++ b/client/app/associate-form.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import Navbar from '../src/components/Navbar';
+
+const AssociateFormScreen = () => {
+  return (
+    <View style={styles.container}>
+      <Navbar />
+      <View style={styles.content}>
+        <Text style={styles.title}>Formulario de Asociación</Text>
+        {/* Aquí irá el formulario de asociación */}
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+  },
+  content: {
+    flex: 1,
+    padding: 20,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '700',
+    textAlign: 'center',
+    marginTop: 20,
+  },
+});
+
+export default AssociateFormScreen;

--- a/client/src/context/AuthContext.js
+++ b/client/src/context/AuthContext.js
@@ -123,9 +123,11 @@ export const AuthProvider = ({ children }) => {
       console.log('Request config:', request);
       const result = await promptAsync();
       console.log('Resultado de autenticación:', result);
+      return result;
     } catch (error) {
       console.error('Error durante el login:', error);
       Alert.alert('Error', 'Ocurrió un error durante el inicio de sesión');
+      throw error;
     }
   };
 

--- a/client/src/screens/LandingScreen.js
+++ b/client/src/screens/LandingScreen.js
@@ -13,16 +13,21 @@ import {
 } from 'react-native';
 import Navbar from '../components/Navbar';
 import { useAuth } from '../context/AuthContext';
+import { useRouter } from 'expo-router';
 
 const LandingScreen = () => {
   const { width, height } = useWindowDimensions();
   const isSmallDevice = height < 700;
   const { login } = useAuth();
+  const router = useRouter();
 
   const handleAssociate = async () => {
     try {
       console.log('ASOCIATE button pressed');
-      await login();
+      const result = await login();
+      if (result?.type === 'success') {
+        router.push('/associate-form');
+      }
     } catch (error) {
       console.error('Error in handleAssociate:', error);
       Alert.alert('Error', 'No se pudo iniciar el proceso de asociación');


### PR DESCRIPTION
## Summary
- make `login` return the auth result
- navigate to new *associate-form* page when login succeeds
- stub out new associate form screen

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842fdf2c7d08323bf130f0ec9c3106d