### PR TITLE
Add simple Express backend

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,19 @@
+# API Backend
+
+This folder contains a simple Express backend connected to PostgreSQL. It exposes a single endpoint to create users.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+2. Provide a `DATABASE_URL` environment variable pointing to your PostgreSQL instance. You can also set `PORT` to change the listening port (defaults to `3001`).
+
+3. Start the server:
+   ```bash
+   npm start
+   ```
+
+When the server starts, it will automatically create a `users` table if it does not already exist.

--- a/api/db.js
+++ b/api/db.js
@@ -1,0 +1,22 @@
+const { Pool } = require('pg');
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+});
+
+async function init() {
+  await pool.query(`CREATE TABLE IF NOT EXISTS users (
+    id SERIAL PRIMARY KEY,
+    username VARCHAR(50) UNIQUE NOT NULL,
+    password VARCHAR(255) NOT NULL
+  )`);
+}
+
+init().catch(err => {
+  console.error('Failed to initialize database:', err);
+  process.exit(1);
+});
+
+module.exports = {
+  query: (text, params) => pool.query(text, params),
+};

--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,27 @@
+require('dotenv').config();
+const express = require('express');
+const db = require('./db');
+
+const app = express();
+app.use(express.json());
+
+app.post('/users', async (req, res) => {
+  const { username, password } = req.body;
+  if (!username || !password) {
+    return res.status(400).json({ error: 'Username and password required' });
+  }
+  try {
+    const result = await db.query(
+      'INSERT INTO users (username, password) VALUES ($1, $2) RETURNING id',
+      [username, password]
+    );
+    res.status(201).json({ id: result.rows[0].id });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+app.listen(process.env.PORT || 3001, () => {
+  console.log(`API listening on port ${process.env.PORT || 3001}`);
+});

--- a/api/package.json
+++ b/api/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "api",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "pg": "^8.11.3",
+    "dotenv": "^16.4.5"
+  }
+}


### PR DESCRIPTION
## Summary
- create `api` folder with Express server
- connect to PostgreSQL and ensure a `users` table exists
- document how to start the API

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68431aaf8b6c8323b0365c21a5af3af3