### PR TITLE
Fix navigation call after form submit

### DIFF
--- a/client/app/associate-form.js
+++ b/client/app/associate-form.js
@@ -1,11 +1,11 @@
-;
-
 import React, { useState } from 'react';
 import { View, Text, TextInput, Button, StyleSheet, Alert, ScrollView } from 'react-native';
+import { useRouter } from 'expo-router';
 import { useAuth } from '../src/context/AuthContext';
 
 
-const AssociateFormScreen = ({ navigation }) => {
+const AssociateFormScreen = () => {
+  const router = useRouter();
   const { user, token } = useAuth(); // asumimos que ya tenés esto
   const [formData, setFormData] = useState({
     nombre: '',
@@ -33,7 +33,7 @@ const AssociateFormScreen = ({ navigation }) => {
       const data = await res.json();
       if (res.ok) {
         Alert.alert("Listo", "¡Gracias por asociarte!");
-        navigation.navigate("Home"); // o a donde corresponda
+        router.push('/'); // navega a la pantalla principal
       } else {
         console.error(data);
         Alert.alert("Error", "No se pudo guardar la asociación");

--- a/client/src/screens/FormAsosiationScreen.jsx
+++ b/client/src/screens/FormAsosiationScreen.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { View, Text, TextInput, Button, StyleSheet, Alert, ScrollView } from 'react-native';
-import { useAuth } from '../src/context/AuthContext';
+import { useAuth } from '../context/AuthContext';
 
 
 const FormularioAsociacionScreen = ({ navigation }) => {


### PR DESCRIPTION
## Summary
- use Expo router in associate form
- fix path to AuthContext for spare screen

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ad9484acc832381dbece565e5fc0a