### PR TITLE
Add Sequelize model and endpoint for Asociado

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -1,6 +1,6 @@
 # API Backend
 
-This folder contains a simple Express backend connected to PostgreSQL. It exposes a single endpoint to create users.
+This folder contains a simple Express backend connected to PostgreSQL using Sequelize. It exposes an endpoint to create `Asociado` records.
 
 ## Setup
 
@@ -16,4 +16,16 @@ This folder contains a simple Express backend connected to PostgreSQL. It expose
    npm start
    ```
 
-When the server starts, it will automatically create a `users` table if it does not already exist.
+When the server starts it will sync the Sequelize models and create the `asociados` table if it does not exist.
+
+## Crear un asociado
+
+Send a `POST` request to `/api/asociado` with a JSON body containing at least `nombre`, `apellido` and `email`. Example using cURL:
+
+```bash
+curl -X POST http://localhost:3001/api/asociado \
+  -H "Content-Type: application/json" \
+  -d '{"nombre":"Juan","apellido":"Perez","email":"juan@test.com"}'
+```
+
+You can also test the endpoint using Postman by sending a similar request.

--- a/api/db.js
+++ b/api/db.js
@@ -1,29 +1,21 @@
-const { Pool } = require('pg');
+const { Sequelize } = require('sequelize');
 require('dotenv').config();
 
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
+const sequelize = new Sequelize(process.env.DATABASE_URL, {
+  dialect: 'postgres',
+  dialectOptions: process.env.NODE_ENV === 'production' ? { ssl: { rejectUnauthorized: false } } : {},
 });
 
 async function init() {
   try {
-    await pool.query(`
-      CREATE TABLE IF NOT EXISTS users (
-        id SERIAL PRIMARY KEY,
-        username VARCHAR(50) UNIQUE NOT NULL,
-        password VARCHAR(255) NOT NULL
-      )
-    `);
-    console.log("✅ Tabla 'users' verificada o creada.");
+    await sequelize.authenticate();
+    console.log('✅ Conexión con PostgreSQL establecida.');
   } catch (err) {
-    console.error('❌ Error inicializando la base:', err);
+    console.error('❌ Error al conectar a la base:', err);
     process.exit(1);
   }
 }
 
 init();
 
-module.exports = {
-  query: (text, params) => pool.query(text, params),
-};
+module.exports = sequelize;

--- a/api/index.js
+++ b/api/index.js
@@ -1,25 +1,62 @@
 require('dotenv').config();
 const express = require('express');
-const db = require('./db');
+const sequelize = require('./db');
+const Asociado = require('./models/Asociado');
 
 const app = express();
 app.use(express.json());
 
-app.post('/users', async (req, res) => {
-  const { username, password } = req.body;
+// Sincronizar modelos con la base al iniciar
+sequelize.sync();
 
-  if (!username || !password) {
-    return res.status(400).json({ error: 'Username and password required' });
+app.post('/api/asociado', async (req, res) => {
+  const {
+    nombre,
+    apellido,
+    fechaNacimiento,
+    dni,
+    email,
+    telefono,
+    calle,
+    numero,
+    ciudad,
+    codigoPostal,
+    provincia,
+    observaciones,
+    reprocan,
+    numeroReprocan,
+    vencimiento,
+    fotoReprocan,
+    numeroGestor,
+  } = req.body;
+
+  if (!nombre || !apellido || !email) {
+    return res.status(400).json({ error: 'nombre, apellido y email son obligatorios' });
   }
 
   try {
-    const result = await db.query(
-      'INSERT INTO users (username, password) VALUES ($1, $2) RETURNING id',
-      [username, password]
-    );
-    res.status(201).json({ id: result.rows[0].id });
+    const nuevo = await Asociado.create({
+      nombre,
+      apellido,
+      fechaNacimiento,
+      dni,
+      email,
+      telefono,
+      calle,
+      numero,
+      ciudad,
+      codigoPostal,
+      provincia,
+      observaciones,
+      reprocan,
+      numeroReprocan,
+      vencimiento,
+      fotoReprocan,
+      numeroGestor,
+    });
+    res.status(201).json(nuevo);
   } catch (err) {
-    console.error('❌ Error en inserción:', err);
+    console.error('❌ Error al crear asociado:', err);
     res.status(500).json({ error: 'Database error' });
   }
 });

--- a/api/models/Asociado.js
+++ b/api/models/Asociado.js
@@ -1,0 +1,26 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../db');
+
+const Asociado = sequelize.define('Asociado', {
+  nombre: { type: DataTypes.STRING, allowNull: false },
+  apellido: { type: DataTypes.STRING, allowNull: false },
+  fechaNacimiento: { type: DataTypes.DATEONLY },
+  dni: { type: DataTypes.STRING },
+  email: { type: DataTypes.STRING, allowNull: false },
+  telefono: { type: DataTypes.STRING },
+  calle: { type: DataTypes.STRING },
+  numero: { type: DataTypes.STRING },
+  ciudad: { type: DataTypes.STRING },
+  codigoPostal: { type: DataTypes.STRING },
+  provincia: { type: DataTypes.STRING },
+  observaciones: { type: DataTypes.TEXT },
+  reprocan: { type: DataTypes.BOOLEAN, defaultValue: false },
+  numeroReprocan: { type: DataTypes.STRING },
+  vencimiento: { type: DataTypes.DATE },
+  fotoReprocan: { type: DataTypes.STRING },
+  numeroGestor: { type: DataTypes.STRING },
+}, {
+  tableName: 'asociados',
+});
+
+module.exports = Asociado;

--- a/api/package.json
+++ b/api/package.json
@@ -8,6 +8,8 @@
   "dependencies": {
     "dotenv": "^16.5.0",
     "express": "^4.19.2",
-    "pg": "^8.11.3"
+    "pg": "^8.11.3",
+    "sequelize": "^6.37.1",
+    "pg-hstore": "^2.3.4"
   }
 }


### PR DESCRIPTION
## Summary
- connect to PostgreSQL using Sequelize
- define `Asociado` model
- expose `POST /api/asociado` endpoint
- document how to run and test the API

## Testing
- `npm start` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_685d524d47088323b02b8ed64c020c77