### PR TITLE
Fix multiple login attempts with AuthSession

### DIFF
--- a/client/src/context/AuthContext.js
+++ b/client/src/context/AuthContext.js
@@ -33,6 +33,7 @@ const AuthContext = createContext(null);
 export const AuthProvider = ({ children }) => {
   const [user, setUser] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [isAuthenticating, setIsAuthenticating] = useState(false);
 
   const [request, response, promptAsync] = useAuthRequest(
     {
@@ -118,6 +119,10 @@ export const AuthProvider = ({ children }) => {
 
   const login = async () => {
     try {
+      if (isAuthenticating) {
+        return { type: 'locked' };
+      }
+      setIsAuthenticating(true);
       console.log('Iniciando proceso de login...');
       console.log('Redirect URI que se está usando:', redirectUri);
       console.log('Request config:', request);
@@ -128,6 +133,8 @@ export const AuthProvider = ({ children }) => {
       console.error('Error durante el login:', error);
       Alert.alert('Error', 'Ocurrió un error durante el inicio de sesión');
       throw error;
+    } finally {
+      setIsAuthenticating(false);
     }
   };
 
@@ -142,10 +149,11 @@ export const AuthProvider = ({ children }) => {
   };
 
   return (
-    <AuthContext.Provider value={{ 
-      user, 
-      isLoading, 
-      login, 
+    <AuthContext.Provider value={{
+      user,
+      isLoading,
+      isAuthenticating,
+      login,
       logout
     }}>
       {children}

--- a/client/src/screens/LandingScreen.js
+++ b/client/src/screens/LandingScreen.js
@@ -18,7 +18,7 @@ import { useRouter } from 'expo-router';
 const LandingScreen = () => {
   const { width, height } = useWindowDimensions();
   const isSmallDevice = height < 700;
-  const { login } = useAuth();
+  const { login, isAuthenticating } = useAuth();
   const router = useRouter();
 
   const handleAssociate = async () => {
@@ -71,10 +71,14 @@ const LandingScreen = () => {
 
         {/* Buttons Section */}
         <View style={styles.buttonContainer}>
-          <TouchableOpacity 
-            style={styles.button}
+          <TouchableOpacity
+            style={[
+              styles.button,
+              isAuthenticating && styles.buttonDisabled
+            ]}
             activeOpacity={0.8}
             onPress={handleAssociate}
+            disabled={isAuthenticating}
           >
             <Text style={styles.buttonText}>
               ASOCIATE
@@ -165,6 +169,9 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.3,
     shadowRadius: 4.65,
     elevation: 8,
+  },
+  buttonDisabled: {
+    opacity: 0.6,
   },
   buttonText: {
     fontFamily: Platform.OS === 'ios' ? 'SF Pro Display' : 'Roboto',


### PR DESCRIPTION
## Summary
- add isAuthenticating state to guard against multiple AuthSession prompts
- expose isAuthenticating through AuthContext
- disable "ASOCIATE" button while authentication is active

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` in `client` *(fails: expo not found)*


------
https://chatgpt.com/codex/tasks/task_e_685d5ecf3e488323a501d75a06287b0b