### PR TITLE
Simplify backend bootstrap

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -6,62 +6,16 @@ const Asociado = require('./models/Asociado');
 const app = express();
 app.use(express.json());
 
-// Sincronizar modelos con la base al iniciar
-sequelize.sync();
-
-app.post('/api/asociado', async (req, res) => {
-  const {
-    nombre,
-    apellido,
-    fechaNacimiento,
-    dni,
-    email,
-    telefono,
-    calle,
-    numero,
-    ciudad,
-    codigoPostal,
-    provincia,
-    observaciones,
-    reprocan,
-    numeroReprocan,
-    vencimiento,
-    fotoReprocan,
-    numeroGestor,
-  } = req.body;
-
-  if (!nombre || !apellido || !email) {
-    return res.status(400).json({ error: 'nombre, apellido y email son obligatorios' });
-  }
-
+async function startServer() {
   try {
-    const nuevo = await Asociado.create({
-      nombre,
-      apellido,
-      fechaNacimiento,
-      dni,
-      email,
-      telefono,
-      calle,
-      numero,
-      ciudad,
-      codigoPostal,
-      provincia,
-      observaciones,
-      reprocan,
-      numeroReprocan,
-      vencimiento,
-      fotoReprocan,
-      numeroGestor,
+    await sequelize.sync();
+    const PORT = process.env.PORT || 3001;
+    app.listen(PORT, () => {
+      console.log(`🚀 Servidor escuchando en el puerto ${PORT}`);
     });
-    res.status(201).json(nuevo);
   } catch (err) {
-    console.error('❌ Error al crear asociado:', err);
-    res.status(500).json({ error: 'Database error' });
+    console.error('❌ Error al sincronizar la base de datos:', err);
   }
-});
+}
 
-const PORT = process.env.PORT || 3001;
-app.listen(PORT, () => {
-  console.log(`🚀 API escuchando en el puerto ${PORT}`);
-});
+startServer();


### PR DESCRIPTION
## Summary
- minimize API server to just bootstrap
- sync Sequelize models on start

## Testing
- `node index.js` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_685d7a93605083239ea48d9f396b5a0c