### PR TITLE
Fix API port mismatch

### DIFF
--- a/client/app/associate-form.js
+++ b/client/app/associate-form.js
@@ -9,7 +9,9 @@ import {
   Modal
 } from 'react-native';
 
-const API_URL = 'http://localhost:3001/api/asociado';
+// The backend listens on the port defined in api/.env (5001 by default).
+// Point the form submission to that port to avoid connection errors.
+const API_URL = 'http://localhost:5001/api/asociado';
 
 const AssociateFormScreen = () => {
   const initialForm = {


### PR DESCRIPTION
## Summary
- update API URL in `associate-form.js` to match backend port

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d85eb07608323976f20fb34723f35