### PR TITLE
Use placeholder for public API URL

### DIFF
--- a/client/app/associate-form.js
+++ b/client/app/associate-form.js
@@ -10,8 +10,9 @@ import {
 } from 'react-native';
 
 // The backend listens on the port defined in api/.env (5001 by default).
-// Point the form submission to that port to avoid connection errors.
-const API_URL = 'http://localhost:5001/api/asociado';
+// Replace the placeholder below with the public ngrok URL to test on a device
+// or the Expo web browser. Example: 'https://abcd1234.ngrok-free.app/api/asociado'
+const API_URL = 'https://YOUR_NGROK_URL/api/asociado';
 
 const AssociateFormScreen = () => {
   const initialForm = {


### PR DESCRIPTION
## Summary
- guide devs by showing where to paste their public API URL

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ea74f87988323a604baa846cbd3f0