### PR TITLE
Configure Express API with asociado route

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,31 +1,32 @@
 require('dotenv').config();
 const express = require('express');
+const cors = require('cors');
+const asociadoRoutes = require('./routes/asociado.route');
 const sequelize = require('./db');
-const Asociado = require('./models/Asociado');
 
 const app = express();
-app.use(express.json());
 
-// Ruta para crear un asociado
-app.post('/api/asociado', async (req, res) => {
-  try {
-    const nuevo = await Asociado.create(req.body);
-    res.status(201).json(nuevo);
-  } catch {
-    res.status(500).json({ message: 'Error interno al crear el asociado' });
-  }
+app.use(cors({ origin: '*' }));
+app.options('*', cors({ origin: '*' }));
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+
+app.get('/', (req, res) => {
+  res.send('API funcionando 👌');
 });
 
-async function startServer() {
+app.use('/api/asociado', asociadoRoutes);
+
+async function start() {
   try {
     await sequelize.sync();
-    const PORT = process.env.PORT || 3001;
+    const PORT = process.env.PORT || 5001;
     app.listen(PORT, () => {
-      console.log(`🚀 Servidor escuchando en el puerto ${PORT}`);
+      console.log('Servidor corriendo…');
     });
   } catch (err) {
-    console.error('❌ Error al sincronizar la base de datos:', err);
+    console.error('Error al iniciar la aplicación:', err);
   }
 }
 
-startServer();
+start();

--- a/api/package.json
+++ b/api/package.json
@@ -3,13 +3,14 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "start": "node index.js"
+    "start": "nodemon index.js"
   },
   "dependencies": {
     "dotenv": "^16.5.0",
     "express": "^4.19.2",
     "pg": "^8.11.3",
     "sequelize": "^6.37.1",
-    "pg-hstore": "^2.3.4"
+    "pg-hstore": "^2.3.4",
+    "cors": "^2.8.5"
   }
 }

--- a/api/routes/asociado.route.js
+++ b/api/routes/asociado.route.js
@@ -8,7 +8,6 @@ router.post('/', async (req, res) => {
     const nuevo = await Asociado.create(req.body);
     res.status(201).json(nuevo);
   } catch (err) {
-    console.error(err);
     res.status(500).json({ error: 'Error al crear asociado' });
   }
 });


### PR DESCRIPTION
## Summary
- create asociado route
- configure Express server with cors, routing and startup
- update api `package.json` with cors and nodemon

## Testing
- `npm test` *(fails: Missing script)*
- `npm start` *(fails: nodemon not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ebb5c38448323aff731c9c4bdeceb