### PR TITLE
Add unique email constraint

### DIFF
--- a/api/db/migrations/001_add_unique_email_asociados.sql
+++ b/api/db/migrations/001_add_unique_email_asociados.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "asociados"
+ADD CONSTRAINT u_asociados_email UNIQUE (email);

--- a/api/models/Asociado.js
+++ b/api/models/Asociado.js
@@ -6,7 +6,7 @@ const Asociado = sequelize.define('Asociado', {
   apellido: { type: DataTypes.STRING, allowNull: false },
   fechaNacimiento: { type: DataTypes.DATEONLY },
   dni: { type: DataTypes.STRING },
-  email: { type: DataTypes.STRING, allowNull: false },
+  email: { type: DataTypes.STRING, allowNull: false, unique: true },
   telefono: { type: DataTypes.STRING },
   calle: { type: DataTypes.STRING },
   numero: { type: DataTypes.STRING },

--- a/api/routes/asociado.route.js
+++ b/api/routes/asociado.route.js
@@ -8,6 +8,9 @@ router.post('/', async (req, res) => {
     const nuevo = await Asociado.create(req.body);
     res.status(201).json(nuevo);
   } catch (err) {
+    if (err.name === 'SequelizeUniqueConstraintError') {
+      return res.status(409).json({ error: 'El email ya está registrado' });
+    }
     res.status(500).json({ error: 'Error al crear asociado' });
   }
 });


### PR DESCRIPTION
## Summary
- enforce a unique `email` on the `asociados` table via SQL migration
- mark `email` as unique in the `Asociado` model
- return HTTP 409 for duplicate email errors

## Testing
- `npm test --workspaces=false` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68629fdbc5088323b6f762c445ee5634