### PR TITLE
Fix navigation routes and unify names

### DIFF
--- a/client/App.js
+++ b/client/App.js
@@ -8,6 +8,8 @@ import Navbar from './src/components/Navbar';
 
 import LandingScreen from './src/screens/LandingScreen';
 import AssociateFormScreen from './src/screens/AssociateFormScreen';
+import NotFoundScreen from './src/screens/NotFoundScreen';
+import { ROUTES } from './src/navigation/routes';
 
 const Stack = createNativeStackNavigator();
 
@@ -18,8 +20,9 @@ export default function App() {
         <Navbar />
         <NavigationContainer>
           <Stack.Navigator screenOptions={{ headerShown: false }}>
-            <Stack.Screen name="Landing" component={LandingScreen} />
-            <Stack.Screen name="Formulario" component={AssociateFormScreen} />
+            <Stack.Screen name={ROUTES.LANDING} component={LandingScreen} />
+            <Stack.Screen name={ROUTES.FORMULARIO} component={AssociateFormScreen} />
+            <Stack.Screen name={ROUTES.NOT_FOUND} component={NotFoundScreen} />
           </Stack.Navigator>
         </NavigationContainer>
       </SafeAreaView>

--- a/client/app/_layout.tsx
+++ b/client/app/_layout.tsx
@@ -1,11 +1,19 @@
-import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
+import { DarkTheme, DefaultTheme, NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { useFonts } from 'expo-font';
-import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
+import { SafeAreaView } from 'react-native';
 import { AuthProvider } from '../src/context/AuthContext';
+import Navbar from '../src/components/Navbar';
+import LandingScreen from '../src/screens/LandingScreen';
+import AssociateFormScreen from '../src/screens/AssociateFormScreen';
+import NotFoundScreen from '../src/screens/NotFoundScreen';
+import { ROUTES } from '../src/navigation/routes';
 
 import { useColorScheme } from '@/hooks/useColorScheme';
+
+const Stack = createNativeStackNavigator();
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
@@ -20,12 +28,17 @@ export default function RootLayout() {
 
   return (
     <AuthProvider>
-      <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-        <Stack screenOptions={{ headerShown: false }}>
-          <Stack.Screen name="index" options={{ headerShown: false }} />
-        </Stack>
+      <SafeAreaView style={{ flex: 1 }}>
+        <Navbar />
+        <NavigationContainer theme={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+          <Stack.Navigator screenOptions={{ headerShown: false }}>
+            <Stack.Screen name={ROUTES.LANDING} component={LandingScreen} />
+            <Stack.Screen name={ROUTES.FORMULARIO} component={AssociateFormScreen} />
+            <Stack.Screen name={ROUTES.NOT_FOUND} component={NotFoundScreen} />
+          </Stack.Navigator>
+        </NavigationContainer>
         <StatusBar style="auto" />
-      </ThemeProvider>
+      </SafeAreaView>
     </AuthProvider>
   );
 }

--- a/client/src/navigation/AppNavigator.js
+++ b/client/src/navigation/AppNavigator.js
@@ -3,6 +3,8 @@ import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import LandingScreen from '../screens/LandingScreen';
 import AssociateFormScreen from '../screens/AssociateFormScreen';
+import NotFoundScreen from '../screens/NotFoundScreen';
+import { ROUTES } from './routes';
 
 const Stack = createNativeStackNavigator();
 
@@ -10,8 +12,9 @@ export default function AppNavigator() {
   return (
     <NavigationContainer>
       <Stack.Navigator screenOptions={{ headerShown: false }}>
-        <Stack.Screen name="FormAsociation" component={AssociateFormScreen} />
-        <Stack.Screen name="Landing" component={LandingScreen} />
+        <Stack.Screen name={ROUTES.FORMULARIO} component={AssociateFormScreen} />
+        <Stack.Screen name={ROUTES.LANDING} component={LandingScreen} />
+        <Stack.Screen name={ROUTES.NOT_FOUND} component={NotFoundScreen} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/client/src/navigation/routes.js
+++ b/client/src/navigation/routes.js
@@ -1,0 +1,7 @@
+export const ROUTES = {
+  LANDING: 'Landing',
+  FORMULARIO: 'Formulario',
+  NOT_FOUND: 'NotFound',
+};
+
+export default ROUTES;

--- a/client/src/screens/AssociateFormScreen.js
+++ b/client/src/screens/AssociateFormScreen.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { View, Text, TextInput, Button, StyleSheet, Alert, ScrollView } from 'react-native';
 import { useAuth } from '../context/AuthContext';
+import { ROUTES } from '../navigation/routes';
 
 
 const AssociateFormScreen = ({ navigation }) => {
@@ -31,7 +32,7 @@ const AssociateFormScreen = ({ navigation }) => {
       const data = await res.json();
       if (res.ok) {
         Alert.alert("Listo", "¡Gracias por asociarte!");
-        navigation.navigate("Home"); // o a donde corresponda
+        navigation.navigate(ROUTES.LANDING); // o a donde corresponda
       } else {
         console.error(data);
         Alert.alert("Error", "No se pudo guardar la asociación");

--- a/client/src/screens/LandingScreen.js
+++ b/client/src/screens/LandingScreen.js
@@ -12,20 +12,21 @@ import {
   Alert,
 } from 'react-native';
 import { useAuth } from '../context/AuthContext';
-import { useRouter } from 'expo-router';
+import { useNavigation } from '@react-navigation/native';
+import { ROUTES } from '../navigation/routes';
 
 const LandingScreen = () => {
   const { width, height } = useWindowDimensions();
   const isSmallDevice = height < 700;
   const { login } = useAuth();
-  const router = useRouter();
+  const navigation = useNavigation();
 
   const handleAssociate = async () => {
     try {
       console.log('ASOCIATE button pressed');
       const result = await login();
       if (result?.type === 'success') {
-        router.push('/associate-form');
+        navigation.navigate(ROUTES.FORMULARIO);
       }
     } catch (error) {
       console.error('Error in handleAssociate:', error);
@@ -173,4 +174,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default LandingScreen; 
+export default LandingScreen;

--- a/client/src/screens/NotFoundScreen.js
+++ b/client/src/screens/NotFoundScreen.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { ROUTES } from '../navigation/routes';
+
+export default function NotFoundScreen() {
+  const navigation = useNavigation();
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>This screen does not exist.</Text>
+      <TouchableOpacity
+        style={styles.link}
+        onPress={() => navigation.navigate(ROUTES.LANDING)}
+      >
+        <Text style={styles.linkText}>Go to home screen!</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 20,
+  },
+  title: {
+    fontSize: 18,
+    marginBottom: 10,
+  },
+  link: {
+    marginTop: 15,
+    paddingVertical: 15,
+  },
+  linkText: {
+    color: 'blue',
+  },
+});


### PR DESCRIPTION
## Summary
- centralize stack route names in `ROUTES`
- update navigation in `LandingScreen` and `AssociateFormScreen`
- add fallback `NotFoundScreen`
- keep Navbar with a single navigation container
- refactor layout to use the new navigator

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862b8f64ea08323acab4872cc8789da