### PR TITLE
feat: navigate to form after login

### DIFF
--- a/client/src/navigation/AppNavigator.js
+++ b/client/src/navigation/AppNavigator.js
@@ -5,6 +5,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 /* ─── Pantallas ─── */
 import LandingScreen from '../screens/LandingScreen';
 import AssociateFormScreen from '../screens/AssociateFormScreen';
+import { ROUTES } from './routes';
 // import DashboardScreen from '../screens/DashboardScreen';   
 // import LoginScreen from '../screens/LoginScreen';         
 // agrega aquí las que necesites …
@@ -14,11 +15,11 @@ const Stack = createNativeStackNavigator();
 export default function AppNavigator() {
   return (
     <Stack.Navigator
-      initialRouteName="Landing"
+      initialRouteName={ROUTES.LANDING}
       screenOptions={{ headerShown: false }}
     >
-      <Stack.Screen name="Landing"        component={LandingScreen} />
-      <Stack.Screen name="AssociateForm"  component={AssociateFormScreen} />
+      <Stack.Screen name={ROUTES.LANDING}     component={LandingScreen} />
+      <Stack.Screen name={ROUTES.FORMULARIO}  component={AssociateFormScreen} />
       {/* <Stack.Screen name="Dashboard"      component={DashboardScreen} /> */}
       {/* <Stack.Screen name="Login"          component={LoginScreen} /> */}
       {/* <Stack.Screen name="OtraPantalla" component={OtraPantalla} /> */}

--- a/client/src/screens/LandingScreen.js
+++ b/client/src/screens/LandingScreen.js
@@ -24,10 +24,7 @@ const LandingScreen = () => {
   const handleAssociate = async () => {
     try {
       console.log('ASOCIATE button pressed');
-      const result = await login();
-      if (result?.type === 'success') {
-        navigation.navigate(ROUTES.FORMULARIO);
-      }
+      await login('login', () => navigation.navigate(ROUTES.FORMULARIO));
     } catch (error) {
       console.error('Error in handleAssociate:', error);
       Alert.alert('Error', 'No se pudo iniciar el proceso de asociación');


### PR DESCRIPTION
## Summary
- redirect to associate form screen on successful login
- add optional callback to AuthContext login
- update stack names to use ROUTES constant

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862d4d7dcd483239208ea374a965e4d